### PR TITLE
Implement scroll bar speed customization

### DIFF
--- a/Source/Components/ImageGlass.ImageBox/ImageBoxEx.cs
+++ b/Source/Components/ImageGlass.ImageBox/ImageBoxEx.cs
@@ -374,6 +374,32 @@ namespace ImageGlass {
             }
         }
 
+        /// <summary>
+        /// Adjusts scroll based on ImageGlass.Settings.Configs.ImageHorizontalScrollSpeed & ImageGlass.Settings.Configs.ImageVerticaclScrollSpeed
+        /// </summary>
+        /// <param name="horizontalScrollDistance">The distance to move the horizontal scrollbar.</param>
+        /// <param name="verticalScrollDistance">The distance to move the vertical scrollbar.</param>
+        /// <param name="e"></param>
+        public void HandlePan(byte horizontalScrollDistance, byte verticalScrollDistance, KeyEventArgs e) {
+            switch (e.KeyCode) {
+                case Keys.Left:
+                    base.AdjustScroll(-horizontalScrollDistance, 0);
+                    break;
+
+                case Keys.Right:
+                    base.AdjustScroll(horizontalScrollDistance, 0);
+                    break;
+
+                case Keys.Up:
+                    base.AdjustScroll(0, -verticalScrollDistance);
+                    break;
+
+                case Keys.Down:
+                    base.AdjustScroll(0, verticalScrollDistance);
+                    break;
+            }
+        }
+
         #endregion
 
 

--- a/Source/Components/ImageGlass.Library/Language/Language.cs
+++ b/Source/Components/ImageGlass.Library/Language/Language.cs
@@ -430,6 +430,15 @@ namespace ImageGlass.Library {
             Items.Add("frmSetting.lnkResetBackgroundColor", "Reset"); // v4.0
             #endregion
 
+            #region Scrolling
+            Items.Add("frmSetting.lblHeadScrolling", "Scrolling");
+            Items.Add("frmSetting.lblVertScrollSpeed", "Vertical Scroll Speed");
+            Items.Add("frmSetting.lblVertScrollValue", "Current Value: ");
+            Items.Add("frmSetting.lblHorzScrollSpeed", "Horizontal Scroll Speed");
+            Items.Add("frmSetting.lblHorzScrollValue", "Current Value: ");
+
+            #endregion
+
             #region Others
             Items.Add("frmSetting.lblHeadOthers", "Others"); //v4.0
             Items.Add("frmSetting.chkStartWithOs", "Start with OS"); //v8.4

--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -364,6 +364,16 @@ namespace ImageGlass.Settings {
         /// </summary>
         public static int ImageEditQuality { get; set; } = 100;
 
+        /// <summary>
+        /// Gets, sets the vertical scroll speed for viewing images.
+        /// </summary>
+        public static byte ImageVerticalScrollSpeed { get; set; } = 10;
+
+        /// <summary>
+        /// Gets, sets the horizontal scroll speed for viewing images.
+        /// </summary>
+        public static byte ImageHorizontalScrollSpeed { get; set; } = 10;
+
         #endregion
 
 
@@ -686,6 +696,9 @@ namespace ImageGlass.Settings {
             ToolbarIconHeight = Get<uint>(nameof(ToolbarIconHeight), ToolbarIconHeight);
             ImageEditQuality = Get<int>(nameof(ImageEditQuality), ImageEditQuality);
 
+            ImageVerticalScrollSpeed = Get<byte>(nameof(ImageVerticalScrollSpeed), ImageVerticalScrollSpeed);
+            ImageHorizontalScrollSpeed = Get<byte>(nameof(ImageHorizontalScrollSpeed), ImageHorizontalScrollSpeed);
+
             #endregion
 
             #region Enum items
@@ -904,7 +917,8 @@ namespace ImageGlass.Settings {
             Set(nameof(ZoomLockValue), ZoomLockValue);
             Set(nameof(ToolbarIconHeight), ToolbarIconHeight);
             Set(nameof(ImageEditQuality), ImageEditQuality);
-
+            Set(nameof(ImageVerticalScrollSpeed), ImageVerticalScrollSpeed);
+            Set(nameof(ImageHorizontalScrollSpeed), ImageHorizontalScrollSpeed);
             #endregion
 
             #region Enum items

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -1167,8 +1167,12 @@ namespace ImageGlass {
                 if (Configs.KeyComboActions[KeyCombos.LeftRight] == AssignableActions.PrevNextImage) {
                     e.Handled = true; // Issue #963: don't let ImageBox see the keystroke!
                     _ = NextPicAsync(-1);
+                } 
+                else {
+                    picMain.HandlePan(Configs.ImageHorizontalScrollSpeed, Configs.ImageVerticalScrollSpeed, e);
+                    e.Handled = true;
                 }
-                return; // fall-through lets pan happen
+                return;
             }
             if (!ignore && e.KeyValue == (int)Keys.PageUp && hasNoMods) {
                 var action = Configs.KeyComboActions[KeyCombos.PageUpDown];
@@ -1193,8 +1197,13 @@ namespace ImageGlass {
                 if (Configs.KeyComboActions[KeyCombos.LeftRight] == AssignableActions.PrevNextImage) {
                     e.Handled = true; // Issue #963: don't let ImageBox see the keystroke!
                     _ = NextPicAsync(1);
+                } 
+                else 
+                {
+                    picMain.HandlePan(Configs.ImageHorizontalScrollSpeed, Configs.ImageVerticalScrollSpeed, e);
+                    e.Handled = true;
                 }
-                return; // fall-through lets pan happen
+                return;
             }
             if (!ignore && e.KeyValue == (int)Keys.PageDown && hasNoMods) {
                 var action = Configs.KeyComboActions[KeyCombos.PageUpDown];
@@ -1217,6 +1226,11 @@ namespace ImageGlass {
                     mnuMainZoomIn_Click(null, null);
                     e.Handled = true;
                 }
+                else {
+                    // Assume action is pan.
+                    picMain.HandlePan(Configs.ImageHorizontalScrollSpeed, Configs.ImageVerticalScrollSpeed, e);
+                    e.Handled = true;
+                }
                 return; // fall-through lets pan happen
             }
             #endregion
@@ -1229,6 +1243,12 @@ namespace ImageGlass {
                     mnuMainZoomOut_Click(null, null);
                     e.Handled = true;
                 }
+                else {
+                    // Assume action is pan.
+                    picMain.HandlePan(Configs.ImageHorizontalScrollSpeed, Configs.ImageVerticalScrollSpeed, e);
+                    e.Handled = true;
+                }
+                // Handle pan events.
                 return; // fall-through lets pan happen
             }
             #endregion
@@ -5634,9 +5654,16 @@ namespace ImageGlass {
 
 
 
+
         #endregion
 
-        
+        private void picMain_Click(object sender, EventArgs e) {
+
+        }
+
+        private void picMain_KeyDown(object sender, KeyEventArgs e) {
+
+        }
     }
 
 

--- a/Source/ImageGlass/frmSetting.cs
+++ b/Source/ImageGlass/frmSetting.cs
@@ -211,6 +211,11 @@ namespace ImageGlass {
             lblBackGroundColor.Text = lang[$"{Name}.{nameof(lblBackGroundColor)}"];
             lnkResetBackgroundColor.Text = lang[$"{Name}.{nameof(lnkResetBackgroundColor)}"];
 
+            // Scrolling
+            lblHeadScrolling.Text = lang[$"{Name}.{nameof(lblHeadScrolling)}"];
+            lblVertScrollValue.Text = lang[$"{Name}.{nameof(lblVertScrollValue)}"];
+            lblHorzScrollValue.Text = lang[$"{Name}.{nameof(lblHorzScrollValue)}"];
+
             // Others
             lblHeadOthers.Text = lang[$"{Name}.{nameof(lblHeadOthers)}"];
             chkStartWithOs.Text = lang[$"{Name}.{nameof(chkStartWithOs)}"];
@@ -511,6 +516,8 @@ namespace ImageGlass {
             chkShowToast.Checked = Configs.IsShowToast;
             chkUseTouchGesture.Checked = Configs.IsUseTouchGesture;
             picBackgroundColor.BackColor = Configs.BackgroundColor;
+            tbrVertScroll.Value = Configs.ImageVerticalScrollSpeed;
+            tbrHorzScroll.Value = Configs.ImageHorizontalScrollSpeed;
         }
 
         private void lnkConfigDir_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
@@ -533,6 +540,18 @@ namespace ImageGlass {
 
         private void lnkResetBackgroundColor_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
             picBackgroundColor.BackColor = Configs.Theme.BackgroundColor;
+        }
+
+        private void tbrVertScroll_ValueChanged(object sender, EventArgs e) {
+            // TODO: Make complaint with language packs OR maybe seperate the labels.
+            lblVertScrollValue.Text =
+                $"{Configs.Language.Items[$"{Name}.{nameof(lblVertScrollValue)}"]}" + tbrVertScroll.Value;
+        }
+
+        private void tbrHorzScroll_ValueChanged(object sender, EventArgs e) {
+            // TODO: Make complaint with language packs OR maybe seperate the labels.
+            lblHorzScrollValue.Text =
+                $"{Configs.Language.Items[$"{Name}.{nameof(lblHorzScrollValue)}"]}" + tbrHorzScroll.Value;
         }
 
         #endregion
@@ -1869,6 +1888,10 @@ namespace ImageGlass {
             Configs.IsStartWithOs = chkStartWithOs.Checked;
             Helper.SetStartWithOS(Configs.IsStartWithOs);
 
+            // Scrolling
+            Configs.ImageVerticalScrollSpeed = (byte)tbrVertScroll.Value;
+            Configs.ImageHorizontalScrollSpeed = (byte)tbrHorzScroll.Value;
+
             Configs.IsContinueRunningBackground = chkContinueRunningBackground.Checked;
             Configs.IsAllowMultiInstances = chkAllowMultiInstances.Checked;
             Configs.IsPressESCToQuit = chkESCToQuit.Checked;
@@ -2176,6 +2199,5 @@ namespace ImageGlass {
         }
 
         #endregion
-
     }
 }


### PR DESCRIPTION
New Feature Commit

The user will now be able to scroll the main image viewer at customizable speeds. This commit excludes the designer editions.

- Added two new settings: `ImageHorizontalScrollSpeed` & `ImageVericalScrollSpeed`

- Added UI text to `Language.cs`

- Added HandlePan() to `ImageBoxEx.cs` to use settings instead of pre-defined scrollbar values.

- Handled KeyDown events for possible panning events.